### PR TITLE
chore: update action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
         git push origin --tags
     
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: v${{ steps.bump.outputs.version }}
         name: Release v${{ steps.bump.outputs.version }}


### PR DESCRIPTION
Updates softprops/action-gh-release from v1 to v2 for latest features and security fixes.